### PR TITLE
fix(i18n): show text correctly in production build

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -12,7 +12,7 @@ import { setupFileHandlers } from './modules/fileManager.js'
 import { setupWindowHandlers } from './modules/windowManager.js'
 import { setupProtocol } from './modules/protocolHandler.js'
 import { setupSettingsHandlers, sendSettingsToRenderer, settings } from './modules/settingsManager.js'
-import { loadLocales, t as et } from './utils/i18n.js'
+import { t as et } from './utils/i18n.js'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
@@ -25,9 +25,6 @@ export const MAIN_DIST = path.join(process.env.APP_ROOT, 'dist-electron')
 export const RENDERER_DIST = path.join(process.env.APP_ROOT, 'dist')
 
 process.env.VITE_PUBLIC = VITE_DEV_SERVER_URL ? path.join(process.env.APP_ROOT, 'public') : RENDERER_DIST
-
-// Load i18n for electron process
-loadLocales(process.env.APP_ROOT)
 
 let win: BrowserWindow | null
 let tray: Tray | null = null

--- a/electron/utils/i18n.ts
+++ b/electron/utils/i18n.ts
@@ -1,28 +1,14 @@
-import fs from 'node:fs'
-import path from 'node:path'
+import enUS from '../../src/locales/en-US.json'
+import zhCN from '../../src/locales/zh-CN.json'
+import jaJP from '../../src/locales/ja-JP.json'
 
 type LocaleMessages = Record<string, any>
 
 let currentLocale = 'en-US'
-const locales: Record<string, LocaleMessages> = {}
-
-/**
- * Load locale files from src/locales directory.
- * In production, these are bundled into the dist folder.
- */
-export function loadLocales(appRoot: string) {
-  const localeDir = path.join(appRoot, 'src', 'locales')
-  const fallbackDir = path.join(appRoot, 'dist', 'locales')
-
-  const dir = fs.existsSync(localeDir) ? localeDir : fallbackDir
-
-  for (const file of ['en-US.json', 'zh-CN.json', 'ja-JP.json']) {
-    const filePath = path.join(dir, file)
-    if (fs.existsSync(filePath)) {
-      const localeName = file.replace('.json', '')
-      locales[localeName] = JSON.parse(fs.readFileSync(filePath, 'utf-8'))
-    }
-  }
+const locales: Record<string, LocaleMessages> = {
+  'en-US': enUS,
+  'zh-CN': zhCN,
+  'ja-JP': jaJP,
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,13 +16,12 @@
         "dayjs": "^1.11.19",
         "echarts": "^5.6.0",
         "ini": "^5.0.0",
-        "mitt": "^3.0.1",
         "naive-ui": "^2.43.2",
         "pinia": "^3.0.3",
         "uuid": "^11.1.0",
         "vue": "^3.4.21",
         "vue-echarts": "^7.0.3",
-        "vue-i18n": "^12.0.0-alpha.3",
+        "vue-i18n": "^11.2.8",
         "vue-router": "^4.5.1"
       },
       "devDependencies": {
@@ -1555,42 +1554,14 @@
       }
     },
     "node_modules/@intlify/core-base": {
-      "version": "12.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-12.0.0-alpha.3.tgz",
-      "integrity": "sha512-LEvBHBUbiOOtIBkp4IIQENVC5Fg2YHsvdXN1+WRIxQ8hzHbHSBiqZ2l68B/yg8sE1a4S7dqhkaAedunShWPH+Q==",
+      "version": "11.2.8",
+      "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-11.2.8.tgz",
+      "integrity": "sha512-nBq6Y1tVkjIUsLsdOjDSJj4AsjvD0UG3zsg9Fyc+OivwlA/oMHSKooUy9tpKj0HqZ+NWFifweHavdljlBLTwdA==",
       "license": "MIT",
       "dependencies": {
-        "@intlify/message-compiler": "12.0.0-alpha.3",
-        "@intlify/shared": "12.0.0-alpha.3"
+        "@intlify/message-compiler": "11.2.8",
+        "@intlify/shared": "11.2.8"
       },
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/kazupon"
-      }
-    },
-    "node_modules/@intlify/core-base/node_modules/@intlify/message-compiler": {
-      "version": "12.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-12.0.0-alpha.3.tgz",
-      "integrity": "sha512-mDDTN3gfYOHhBnpnlby19UHyvMaOnzdlpsIrxUfs44R/vCATfn8pMOkE8PXD2t410xkocEj3FpDcC9XC/0v4Dg==",
-      "license": "MIT",
-      "dependencies": {
-        "@intlify/shared": "12.0.0-alpha.3",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/kazupon"
-      }
-    },
-    "node_modules/@intlify/core-base/node_modules/@intlify/shared": {
-      "version": "12.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-12.0.0-alpha.3.tgz",
-      "integrity": "sha512-ryaNYBvxQjyJUmVuBBg+HHUsmGnfxcEUPR0NCeG4/K9N2qtyFE35C80S15IN6iYFE2MGWLN7HfOSyg0MXZIc9w==",
-      "license": "MIT",
       "engines": {
         "node": ">= 16"
       },
@@ -1662,41 +1633,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/@intlify/vue-i18n-core": {
-      "version": "12.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@intlify/vue-i18n-core/-/vue-i18n-core-12.0.0-alpha.3.tgz",
-      "integrity": "sha512-YwAfTQILHN+VoK0P/Yv47GbKnEf1lhfbliyVyW3knAL1EmT8m0m3rwffXJnwyQhYw8Jpx85CpL49WkSgyi6d/g==",
-      "license": "MIT",
-      "dependencies": {
-        "@intlify/core-base": "12.0.0-alpha.3",
-        "@intlify/shared": "12.0.0-alpha.3",
-        "@vue/devtools-api": "^6.5.0"
-      },
-      "engines": {
-        "node": ">= 16"
-      },
-      "peerDependencies": {
-        "vue": "^3.0.0"
-      }
-    },
-    "node_modules/@intlify/vue-i18n-core/node_modules/@intlify/shared": {
-      "version": "12.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-12.0.0-alpha.3.tgz",
-      "integrity": "sha512-ryaNYBvxQjyJUmVuBBg+HHUsmGnfxcEUPR0NCeG4/K9N2qtyFE35C80S15IN6iYFE2MGWLN7HfOSyg0MXZIc9w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/kazupon"
-      }
-    },
-    "node_modules/@intlify/vue-i18n-core/node_modules/@vue/devtools-api": {
-      "version": "6.6.4",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
-      "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
-      "license": "MIT"
     },
     "node_modules/@intlify/vue-i18n-extensions": {
       "version": "8.0.0",
@@ -9374,15 +9310,13 @@
       }
     },
     "node_modules/vue-i18n": {
-      "version": "12.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-12.0.0-alpha.3.tgz",
-      "integrity": "sha512-+KQgD9LJoHfGCdJh3gaLdVS/Sps1n860+6wsjyeNLWJeEofjdVH7KPjz4rAeBlTAUaIDlIjHoXQY0Lk+8B6S9w==",
-      "deprecated": "This version is NOT deprecated. Previous deprecation was a mistake.",
+      "version": "11.2.8",
+      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-11.2.8.tgz",
+      "integrity": "sha512-vJ123v/PXCZntd6Qj5Jumy7UBmIuE92VrtdX+AXr+1WzdBHojiBxnAxdfctUFL+/JIN+VQH4BhsfTtiGsvVObg==",
       "license": "MIT",
       "dependencies": {
-        "@intlify/core-base": "12.0.0-alpha.3",
-        "@intlify/shared": "12.0.0-alpha.3",
-        "@intlify/vue-i18n-core": "12.0.0-alpha.3",
+        "@intlify/core-base": "11.2.8",
+        "@intlify/shared": "11.2.8",
         "@vue/devtools-api": "^6.5.0"
       },
       "engines": {
@@ -9393,18 +9327,6 @@
       },
       "peerDependencies": {
         "vue": "^3.0.0"
-      }
-    },
-    "node_modules/vue-i18n/node_modules/@intlify/shared": {
-      "version": "12.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-12.0.0-alpha.3.tgz",
-      "integrity": "sha512-ryaNYBvxQjyJUmVuBBg+HHUsmGnfxcEUPR0NCeG4/K9N2qtyFE35C80S15IN6iYFE2MGWLN7HfOSyg0MXZIc9w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/kazupon"
       }
     },
     "node_modules/vue-i18n/node_modules/@vue/devtools-api": {

--- a/package.json
+++ b/package.json
@@ -22,13 +22,12 @@
     "dayjs": "^1.11.19",
     "echarts": "^5.6.0",
     "ini": "^5.0.0",
-    "mitt": "^3.0.1",
     "naive-ui": "^2.43.2",
     "pinia": "^3.0.3",
     "uuid": "^11.1.0",
     "vue": "^3.4.21",
     "vue-echarts": "^7.0.3",
-    "vue-i18n": "^12.0.0-alpha.3",
+    "vue-i18n": "^11.2.8",
     "vue-router": "^4.5.1"
   },
   "devDependencies": {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
   },
   build: {
     target: 'esnext', // Support latest ES features, including top-level await
+    chunkSizeWarningLimit: 2000, // Increase chunk size warning limit to 2000 KB
   },
   plugins: [
     vue(),


### PR DESCRIPTION
- Downgrade ``vue-i18n`` back to v11.
  ``@intlify/unplugin-vue-i18n`` v11 will pre-compile locale JSON files during build, but the format of the compiled output does not match with the runtime of ``vue-i18n v12 alpha``, resulting in the runtime not being able to parse the translated content, and can only fallback to display the key name. 

- Static import  locale JSON to allow ``vite-plugin-electron`` to inline the JSON content directly into the main process when packaging it.
  In dev mode, ``APP_ROOT`` points to the root directory of the project, ``src/locales/`` exists so it can be read normally. But after packaging, ``src/locales/`` doesn't exist in Electron package and ``dist/locales/`` doesn't exist either, so the translation fails to load.

- Set ``chunkSizeWarningLimit`` to 2000 to avoid warning about large chunk size.

- Remove unused mitt dependency.